### PR TITLE
use crypto module

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ language: node_js
 # define node.js versions to run on
 node_js:
   - "stable"
+  - "9"
+  - "8"
   - "7"
   - "6"
   - "5"

--- a/README.md
+++ b/README.md
@@ -14,6 +14,11 @@ For more information about Node.js timing attacks, please visit https://snyk.io/
 [![Build Status - Tarvis](https://travis-ci.org/Bruce17/safe-compare.svg?style=flat-square&branch=master)](https://travis-ci.org/Bruce17/safe-compare)
 [![Build status - AppVeyor](https://ci.appveyor.com/api/projects/status/ounmeq5c4ajuu7g3/branch/master?svg=true)](https://ci.appveyor.com/project/Bruce17/safe-compare/branch/master)
 
+**NOTICE**:
+
+If you are using Node.js v6.6.0 or higher, you can use [crypto.timingSafeEqual(a, b)](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) from the `crypto` module.
+
+
 ## Installation
 
 ```

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ For more information about Node.js timing attacks, please visit https://snyk.io/
 
 **NOTICE**:
 
-If you are using Node.js v6.6.0 or higher, you can use [crypto.timingSafeEqual(a, b)](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) from the `crypto` module.
+If you are using Node.js v6.6.0 or higher, you can use [crypto.timingSafeEqual(a, b)](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) from the `crypto` module. Keep in mind that the method `crypto.timingSafeEqual` only accepts `Buffer`s with the same length! This bundle will handle strings with different lengths for you.
 
 
 ## Installation

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,6 +3,8 @@ version: "{build}-{branch}"
 
 environment:
   matrix:
+    - nodejs_version: "9"
+    - nodejs_version: "8"
     - nodejs_version: "7"
     - nodejs_version: "6"
     - nodejs_version: "5"

--- a/index.js
+++ b/index.js
@@ -5,14 +5,21 @@
 
 'use strict';
 
+var crypto = require('crypto');
+var bufferAlloc = require('buffer-alloc')
+
+
 /**
- * Do a constant time string comparison. Always compare the complete strings against each other to get a constant time.
- * This method does not short-cut if the two string's length differs.
+ * Do a constant time string comparison. Always compare the complete strings
+ * against each other to get a constant time. This method does not short-cut
+ * if the two string's length differs.
  *
  * @param {string} a
  * @param {string} b
+ * 
+ * @return {boolean}
  */
-module.exports = function safeCompare(a, b) {
+var safeCompare = function safeCompare(a, b) {
     var strA = String(a);
     var strB = String(b);
     var lenA = strA.length;
@@ -29,3 +36,32 @@ module.exports = function safeCompare(a, b) {
 
     return result === 0;
 };
+
+
+/**
+ * Call native "crypto.timingSafeEqual" methods.
+ * All passed values will be converted into strings first.
+ * 
+ * @param {string} a
+ * @param {string} b
+ * 
+ * @return {boolean}
+ */
+var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
+    var strA = String(a);
+    var strB = String(b);
+    
+    var len = Math.max(strA.length, strB.length);
+    
+    var bufA = bufferAlloc(len, strA, 'utf-8');
+    var bufB = bufferAlloc(len, strB, 'utf-8');
+    
+    return crypto.timingSafeEqual(bufA, bufB);
+};
+
+
+module.exports = (
+    typeof crypto.timingSafeEqual !== 'undefined' ?
+        nativeTimingSafeEqual :
+        safeCompare
+);

--- a/index.js
+++ b/index.js
@@ -53,8 +53,8 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     
     var len = Math.max(strA.length, strB.length);
     
-    var bufA = bufferAlloc(len, strA, 'utf-8');
-    var bufB = bufferAlloc(len, strB, 'utf-8');
+    var bufA = bufferAlloc(len, strA, 'binary');
+    var bufB = bufferAlloc(len, strB, 'binary');
     
     return crypto.timingSafeEqual(bufA, bufB);
 };

--- a/package.json
+++ b/package.json
@@ -40,5 +40,8 @@
     "istanbul": "^0.4.5",
     "matcha": "^0.7.0",
     "mocha": "^3.1.2"
+  },
+  "dependencies": {
+    "buffer-alloc": "^1.1.0"
   }
 }


### PR DESCRIPTION
Fix issue https://github.com/Bruce17/safe-compare/issues/4

Try to use [crypto.timingSafeEqual(a, b)](https://nodejs.org/api/crypto.html#crypto_crypto_timingsafeequal_a_b) if possible. Use fallback compare method instead.