### PR TITLE
fix: buffer-alloc pads a buffer by repeating

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,8 +53,10 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     
     var len = Math.max(Buffer.byteLength(strA), Buffer.byteLength(strB));
     
-    var bufA = bufferAlloc(len, strA, 'utf8');
-    var bufB = bufferAlloc(len, strB, 'utf8');
+    var bufA = bufferAlloc(len, 0, 'utf8');
+    bufA.write(strA);
+    var bufB = bufferAlloc(len, 0, 'utf8');
+    bufB.write(strB);
     
     return crypto.timingSafeEqual(bufA, bufB);
 };

--- a/test/test.js
+++ b/test/test.js
@@ -48,6 +48,10 @@ describe('safe compare', function () {
         it('"\\u00e8" against "\\u01e8"', function () {
             assert.equal(false, safeCompare('\u00e8', '\u01e8'));
         });
+        
+        it('"a" against "aaaaaaaaaa"', function () {
+            assert.equal(false, safeCompare('a', 'aaaaaaaaaa'));
+        });
     });
 
     describe('should not throw an error for non string argument', function () {


### PR DESCRIPTION
There seems to be a bug in the code. Since buffer-alloc is not padding with zeros, but rather duplicates the string it was given. For example the string `"a"` will be deemed equal to the string `"aaaaaa"`.

```
> require('safe-compare')('a', 'aaaaaaaaaaaa')
true
```

This pr mitigates this by right-padding the buffer with zeros.