### PR TITLE
Fix leaking length of comparator string

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,7 +16,7 @@ var bufferAlloc = require('buffer-alloc');
  *
  * @param {string} a
  * @param {string} b
- * 
+ *
  * @return {boolean}
  */
 var safeCompare = function safeCompare(a, b) {
@@ -41,24 +41,30 @@ var safeCompare = function safeCompare(a, b) {
 /**
  * Call native "crypto.timingSafeEqual" methods.
  * All passed values will be converted into strings first.
- * 
+ *
+ * Runtime is always corresponding to the length of the first parameter (string
+ * a).
+ *
  * @param {string} a
  * @param {string} b
- * 
+ *
  * @return {boolean}
  */
 var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     var strA = String(a);
     var strB = String(b);
-    
-    var len = Math.max(Buffer.byteLength(strA), Buffer.byteLength(strB));
-    
-    var bufA = bufferAlloc(len, 0, 'utf8');
+    var aLen = Buffer.byteLength(strA);
+    var bLen = Buffer.byteLength(strB);
+
+    // Always use length of a to avoid leaking the length. Even if this is a
+    // false positive because one is a prefix of the other, the explicit length
+    // check at the end will catch that.
+    var bufA = bufferAlloc(aLen, 0, 'utf8');
     bufA.write(strA);
-    var bufB = bufferAlloc(len, 0, 'utf8');
+    var bufB = bufferAlloc(aLen, 0, 'utf8');
     bufB.write(strB);
-    
-    return crypto.timingSafeEqual(bufA, bufB);
+
+    return crypto.timingSafeEqual(bufA, bufB) && aLen === bLen;
 };
 
 

--- a/test/test.js
+++ b/test/test.js
@@ -48,9 +48,17 @@ describe('safe compare', function () {
         it('"\\u00e8" against "\\u01e8"', function () {
             assert.equal(false, safeCompare('\u00e8', '\u01e8'));
         });
-        
+
         it('"a" against "aaaaaaaaaa"', function () {
             assert.equal(false, safeCompare('a', 'aaaaaaaaaa'));
+        });
+
+        it('"prefix" against "pre"', function () {
+            assert.equal(false, safeCompare('prefix', 'pre'));
+        });
+
+        it('"pre" against "prefix"', function () {
+            assert.equal(false, safeCompare('pre', 'prefix'));
         });
     });
 


### PR DESCRIPTION
Avoid leaking the length of the user-controlled parameter by always using the length of only one of the parameters. If you're passing the known password as the first param, runtime will always be constant: great. If you're passing the user supplied password as the first param, runtime will always be corresponding to the length of the user supplied password: also great, not leaking anything the attacker didn't already know.

This only patches the nativeTimingSafeEqual function.