### PR TITLE
Drop Node <5.12 support to remove `buffer-alloc` dependency

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,12 +13,6 @@ environment:
     - nodejs_version: "7"
     - nodejs_version: "6"
     - nodejs_version: "5"
-    - nodejs_version: "4"
-    - nodejs_version: "0.12"
-    - nodejs_version: "0.11"
-    - nodejs_version: "0.10"
-    # io.js
-    - nodejs_version: "1"
 
 platform:
   - x86

--- a/index.js
+++ b/index.js
@@ -6,7 +6,6 @@
 'use strict';
 
 var crypto = require('crypto');
-var bufferAlloc = require('buffer-alloc');
 
 
 /**
@@ -59,9 +58,9 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     // Always use length of a to avoid leaking the length. Even if this is a
     // false positive because one is a prefix of the other, the explicit length
     // check at the end will catch that.
-    var bufA = bufferAlloc(aLen, 0, 'utf8');
+    var bufA = Buffer.allocUnsafe(aLen);
     bufA.write(strA);
-    var bufB = bufferAlloc(aLen, 0, 'utf8');
+    var bufB = Buffer.allocUnsafe(aLen);
     bufB.write(strB);
 
     return crypto.timingSafeEqual(bufA, bufB) && aLen === bLen;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "matcha": "^0.7.0",
     "mocha": "^3.1.2"
   },
-  "dependencies": {
-    "buffer-alloc": "^1.2.0"
+  "engines": {
+    "node": ">=5.12.0"
   }
 }


### PR DESCRIPTION
3 less dependencies to download and audit. Breaking change, but affected Node versions are long EOL.

Alternatives:
1. Raise minimum Node version to 6.6.0 (EOL since 2019), drop https://github.com/Bruce17/safe-compare/blob/8e8c1c462786698971245263cc1b96356a356745/index.js#L72 raising test coverage to 100%.
2. Change minimum Node version to 5.10.0 (EOL since 2016), sacrificing the option to switch to `Buffer.allocUnsafeSlow`.
3. Use https://www.npmjs.com/package/buffer-alloc-unsafe (non-breaking). The buffers aren't returned, so it's safe.