### PR TITLE
Use `buffer-alloc-unsafe`

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@
 'use strict';
 
 var crypto = require('crypto');
-var bufferAlloc = require('buffer-alloc');
+var bufferAllocUnsafe = require('buffer-alloc-unsafe');
 
 
 /**
@@ -59,9 +59,9 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     // Always use length of a to avoid leaking the length. Even if this is a
     // false positive because one is a prefix of the other, the explicit length
     // check at the end will catch that.
-    var bufA = bufferAlloc(aLen, 0, 'utf8');
+    var bufA = bufferAllocUnsafe(aLen);
     bufA.write(strA);
-    var bufB = bufferAlloc(aLen, 0, 'utf8');
+    var bufB = bufferAllocUnsafe(aLen);
     bufB.write(strB);
 
     return crypto.timingSafeEqual(bufA, bufB) && aLen === bLen;

--- a/package.json
+++ b/package.json
@@ -41,6 +41,6 @@
     "mocha": "^3.1.2"
   },
   "dependencies": {
-    "buffer-alloc": "^1.2.0"
+    "buffer-alloc-unsafe": "1.1.0"
   }
 }


### PR DESCRIPTION
Removes 2 dependencies. Zero-filling is unnecessary: both buffers are discarded immediately after comparison.