### PR TITLE
[BREAKING] Drop support for Node <6.6.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,17 +13,11 @@ node_js:
   - "8"
   - "7"
   - "6"
-  - "5"
-  - "4"
-  - "iojs"
-  - "0.12"
-  - "0.11"
-  - "0.10"
 
 # run before everey other script
 before_script:
   - npm install
-  
+
   # New way to prepare codeclimate
   - curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
   - chmod +x ./cc-test-reporter
@@ -41,4 +35,3 @@ after_script:
   - npm run-script coveralls
   # send coverage data to codeclimate
   - ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT
-

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -12,13 +12,6 @@ environment:
     - nodejs_version: "8"
     - nodejs_version: "7"
     - nodejs_version: "6"
-    - nodejs_version: "5"
-    - nodejs_version: "4"
-    - nodejs_version: "0.12"
-    - nodejs_version: "0.11"
-    - nodejs_version: "0.10"
-    # io.js
-    - nodejs_version: "1"
 
 platform:
   - x86

--- a/index.js
+++ b/index.js
@@ -6,36 +6,6 @@
 'use strict';
 
 var crypto = require('crypto');
-var bufferAllocUnsafe = require('buffer-alloc-unsafe');
-
-
-/**
- * Do a constant time string comparison. Always compare the complete strings
- * against each other to get a constant time. This method does not short-cut
- * if the two string's length differs.
- *
- * @param {string} a
- * @param {string} b
- *
- * @return {boolean}
- */
-var safeCompare = function safeCompare(a, b) {
-    var strA = String(a);
-    var strB = String(b);
-    var lenA = strA.length;
-    var result = 0;
-
-    if (lenA !== strB.length) {
-        strB = strA;
-        result = 1;
-    }
-
-    for (var i = 0; i < lenA; i++) {
-        result |= (strA.charCodeAt(i) ^ strB.charCodeAt(i));
-    }
-
-    return result === 0;
-};
 
 
 /**
@@ -59,17 +29,13 @@ var nativeTimingSafeEqual = function nativeTimingSafeEqual(a, b) {
     // Always use length of a to avoid leaking the length. Even if this is a
     // false positive because one is a prefix of the other, the explicit length
     // check at the end will catch that.
-    var bufA = bufferAllocUnsafe(aLen);
+    var bufA = Buffer.allocUnsafe(aLen);
     bufA.write(strA);
-    var bufB = bufferAllocUnsafe(aLen);
+    var bufB = Buffer.allocUnsafe(aLen);
     bufB.write(strB);
 
     return crypto.timingSafeEqual(bufA, bufB) && aLen === bLen;
 };
 
 
-module.exports = (
-    typeof crypto.timingSafeEqual !== 'undefined' ?
-        nativeTimingSafeEqual :
-        safeCompare
-);
+module.exports = nativeTimingSafeEqual;

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "matcha": "^0.7.0",
     "mocha": "^3.1.2"
   },
-  "dependencies": {
-    "buffer-alloc-unsafe": "1.1.0"
+  "engines": {
+    "node": ">=6.6.0"
   }
 }


### PR DESCRIPTION
Makes the package tiny and dependency-free by removing ponyfills needed only by EOL Node.js.

#13 should be released first as 1.1.5.